### PR TITLE
Implement ownership behaviour as its own component

### DIFF
--- a/src/ReplicatedStorage/Client/InstanceComponents/Misc/OwnedObject.lua
+++ b/src/ReplicatedStorage/Client/InstanceComponents/Misc/OwnedObject.lua
@@ -1,0 +1,73 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Trove = require(ReplicatedStorage.Packages.Trove)
+local Comm = require(ReplicatedStorage.Packages.Comm)
+
+--[=[
+	@class OwnedObject
+]=]
+local OwnedObject = {}
+OwnedObject.__index = OwnedObject
+
+function OwnedObject.new(instance: Instance)
+	local clientComm = Comm.ClientComm.new(instance, false, "OwnedObject")
+	local self = setmetatable({}, OwnedObject)
+	self.Instance = instance
+	self._trove = Trove.new()
+
+	-- Add comm to trove
+	self._trove:Add(clientComm)
+
+	-- Get owner ID property
+	self._ownerIdProp = clientComm:GetProperty("OwnerId")
+
+	-- When the owner ID property is uppdated
+	self._ownerIdProp:Observe(function(owner)
+		-- Update the owner
+		self:_setOwner(owner)
+	end)
+
+	return self
+end
+
+function OwnedObject:_getUserId(user: (Player | number)?): number
+	return assert(
+		if type(user) == "number" then
+			user
+		elseif
+			typeof(user) == "Instance" and user:IsA("Player") then user.UserId
+		else nil,
+		"Argument #1 for OwnedObject:IsOwner() must be a Player instance or UserId."
+	)
+end
+
+--[=[
+	@client
+	Returns whether or not the local player owns this object.
+
+	@return boolean
+]=]
+function OwnedObject:IsOwner()
+	return self._ownerId == Players.LocalPlayer.UserId
+end
+
+function OwnedObject:_setOwner(user: (Player | number)?)
+	local ownerId = if user == nil then nil else self:_getUserId(user)
+
+	-- Update ownership properties
+	self._ownerId = ownerId
+end
+
+function OwnedObject:GetOwner(): Player?
+	return self._ownerId and Players:GetPlayerByUserId(self._ownerId)
+end
+
+function OwnedObject:GetOwnerId(): number?
+	return self._ownerId
+end
+
+function OwnedObject:Destroy()
+	self._trove:Clean()
+end
+
+return OwnedObject

--- a/src/ServerScriptService/InstanceComponents/Misc/Character.lua
+++ b/src/ServerScriptService/InstanceComponents/Misc/Character.lua
@@ -1,6 +1,8 @@
 local CollectionService = game:GetService("CollectionService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ServerScriptService = game:GetService("ServerScriptService")
 local Trove = require(ReplicatedStorage.Packages.Trove)
+local BinderService = require(ServerScriptService.Services.BinderService)
 
 local Character = {}
 Character.__index = Character
@@ -22,9 +24,17 @@ function Character.new(instance: Instance)
 	instance:SetAttribute("LookInAir", false)
 
 	-- Add CameraLook tag to the character
+	CollectionService:AddTag(instance, "OwnedObject")
 	CollectionService:AddTag(instance, "CursorLook")
 	CollectionService:AddTag(instance, "FallDamage")
 	CollectionService:AddTag(instance, "OceanDamage")
+
+	-- Get the OwnedObject component
+	local OwnedObject = BinderService:Get("OwnedObject")
+	local ownedObject = OwnedObject:Get(instance)
+
+	-- Apply automatic ownership
+	ownedObject:SetAutomaticOwnership(true)
 
 	return self
 end

--- a/src/ServerScriptService/InstanceComponents/Misc/OwnedObject.lua
+++ b/src/ServerScriptService/InstanceComponents/Misc/OwnedObject.lua
@@ -1,0 +1,128 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Trove = require(ReplicatedStorage.Packages.Trove)
+local Comm = require(ReplicatedStorage.Packages.Comm)
+
+--[=[
+	@class OwnedObject
+]=]
+local OwnedObject = {}
+OwnedObject.__index = OwnedObject
+
+function OwnedObject.new(instance: Instance, owner: (Player | number)?)
+	local serverComm = Comm.ServerComm.new(instance, "OwnedObject")
+	local self = setmetatable({}, OwnedObject)
+	self.Instance = instance
+	self._trove = Trove.new()
+
+	-- Add comm to trove
+	self._trove:Add(serverComm)
+
+	-- Create owner ID property
+	self._ownerIdProp = serverComm:CreateProperty("OwnerId", nil)
+
+	-- Update the owner
+	self:SetOwner(owner)
+
+	return self
+end
+
+function OwnedObject:_getUserId(user: (Player | number)?): number
+	return assert(
+		if type(user) == "number" then
+			user
+		elseif
+			typeof(user) == "Instance" and user:IsA("Player") then user.UserId
+		else nil,
+		"Argument #1 for OwnedObject:IsOwner() must be a Player instance or UserId."
+	)
+end
+
+--[=[
+	@server
+	Tracks the ancestry of the bound instance, treating the top-most ancestor under workspace as the character of a player.
+	Automatically assigns the ownership of this object.
+]=]
+function OwnedObject:SetAutomaticOwnership(state: boolean)
+	if state and not self._ownershipTracking then
+		local function updateOwnershipAuto()
+			local character = self.Instance
+			local owner: Player? = nil
+
+			-- Traverse up ancestry to find the character & owner player
+			repeat
+				owner = Players:GetPlayerFromCharacter(character)
+				if not owner then
+					character = character.Parent
+				end
+			until owner or not character:IsDescendantOf(workspace)
+
+			-- If the owner differs, update it
+			if self:GetOwner() ~= owner then
+				self:SetOwner(owner)
+			end
+		end
+
+		-- Update the owner once immediately
+		updateOwnershipAuto()
+
+		-- When ancestry changes, update the owner
+		self._ownershipTracking = self.Instance.AncestryChanged:Connect(updateOwnershipAuto)
+	elseif not state and self._ownershipTracking then
+		self._ownershipTracking:Disconnect()
+		self._ownershipTracking = nil
+	end
+end
+
+--[=[
+	@server
+	Returns whether or not the given user owns the object.
+	If nil is passed (server-sided), will return true.
+
+	@param user (Player | number)? -- The `Player` or their `UserId`, or `nil` if server-sided.
+	@return boolean
+]=]
+function OwnedObject:IsOwner(user: (Player | number)?)
+	return user == nil or self._ownerId == self:_getUserId(user)
+end
+
+--[=[
+	@server
+	Updates the owner of the instance.
+
+	@param user (Player | number)? -- The `Player` or their `UserId`
+]=]
+function OwnedObject:SetOwner(user: (Player | number)?)
+	local ownerId = if user == nil then nil else self:_getUserId(user)
+
+	-- Update ownership properties
+	self._ownerId = ownerId
+	self._ownerIdProp:Set(ownerId)
+end
+
+--[=[
+	@return Player? -- The owner Player, if they are in the game.
+]=]
+function OwnedObject:GetOwner(): Player?
+	return self._ownerId and Players:GetPlayerByUserId(self._ownerId)
+end
+
+--[=[
+	@return number? -- The owner's ID.
+]=]
+function OwnedObject:GetOwnerId(): number?
+	return self._ownerId
+end
+
+--[=[
+	Destroys the component.
+]=]
+function OwnedObject:Destroy()
+	if self._ownershipTracking then
+		self._ownershipTracking:Disconnect()
+		self._ownershipTracking = nil
+	end
+	self._trove:Clean()
+end
+
+return OwnedObject


### PR DESCRIPTION
- Adds a server & client-sided component called `OwnedObject`. This tag may be applied to any objects owned by a specific player or by the server (e.g. jetpack). This is similar but not related to network ownership.
- Ownership is done by UserId, rather than by Player instance.
- This unifies component's understandings of player ownership, such as for usage with `Comm`.

---

I would like to wait until `Sprint` and `Jetpack` have a chance to be merged into main before merging this.

Resolves #41 