### PR TITLE
Migrate to aftman

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Voltz, open-sourced.
 
 ## Installing tools
 
-1. Install Rust via [rustup](https://rustup.rs/)
-2. Install foreman via `cargo install foreman`
-3. Run `foreman install` within the project root to download and install necessary tools
-4. Run `wally install` to download dependencies via wally
+1. Install [Aftman](https://github.com/LPGhatguy/aftman).
+2. In the project root, run `aftman install` within the project root to download and install all necessary tools.
+3. Run `wally install` to download project dependencies.

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,3 @@
+[tools]
+rojo = "rojo-rbx/rojo@7.2.1"
+wally = "UpliftGames/wally@0.3.1"

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,0 @@
-[tools]
-rojo = { source = "rojo-rbx/rojo", version = "7.2.1" }
-wally = { source = "UpliftGames/wally", version = "0.3.1" }


### PR DESCRIPTION
- Removes `foreman.toml`
- Adds `aftman.toml`
- Update README instructions to reflect changes